### PR TITLE
Verify published 0.2.0 release evidence

### DIFF
--- a/.github/workflows/verify-published-release.yml
+++ b/.github/workflows/verify-published-release.yml
@@ -1,0 +1,50 @@
+name: Verify Published Release
+
+on:
+  pull_request:
+    paths:
+      - .github/workflows/verify-published-release.yml
+      - scripts/verify-published-release.mjs
+      - tests/published-release.test.mjs
+      - manifest.json
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Release tag to verify; defaults to the manifest version
+        required: false
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    env:
+      GITHUB_TOKEN: ${{ github.token }}
+      RELEASE_TAG: ${{ github.event.release.tag_name || inputs.tag || '' }}
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+
+      - name: Set up Node.js 24
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+
+      - name: Test release verifier
+        run: node --test tests/published-release.test.mjs
+
+      - name: Verify published release and Chrome Web Store evidence
+        run: node scripts/verify-published-release.mjs
+
+      - name: Upload verification report
+        uses: actions/upload-artifact@v7
+        with:
+          name: published-release-verification-${{ github.sha }}
+          path: published-release-verification.json
+          if-no-files-found: error
+          retention-days: 30

--- a/.github/workflows/verify-published-release.yml
+++ b/.github/workflows/verify-published-release.yml
@@ -6,7 +6,6 @@ on:
       - .github/workflows/verify-published-release.yml
       - scripts/verify-published-release.mjs
       - tests/published-release.test.mjs
-      - manifest.json
   release:
     types: [published]
   workflow_dispatch:

--- a/scripts/verify-published-release.mjs
+++ b/scripts/verify-published-release.mjs
@@ -1,0 +1,241 @@
+import { createHash } from 'node:crypto';
+import { spawnSync } from 'node:child_process';
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+
+export const RELEASE_RUNTIME_FILES = Object.freeze([
+  'LICENSE',
+  'THIRD_PARTY_NOTICES.md',
+  'assets/icon128.png',
+  'assets/icon16.png',
+  'assets/icon32.png',
+  'assets/icon48.png',
+  'lib/Readability.js',
+  'licenses/Apache-2.0.txt',
+  'manifest.json',
+  'src/background.js',
+  'src/content.js',
+  'src/offscreen.html',
+  'src/offscreen.js',
+  'src/options.css',
+  'src/options.html',
+  'src/options.js',
+  'src/shared.js',
+  'src/storage.js'
+].sort());
+
+export async function verifyPublishedRelease(options = {}) {
+  const manifest = JSON.parse(await readFile(path.join(root, 'manifest.json'), 'utf8'));
+  const repository = options.repository || process.env.GITHUB_REPOSITORY || '646826/page-to-md-pro';
+  const tag = options.tag || process.env.RELEASE_TAG || `v${manifest.version}`;
+  const version = manifest.version;
+  const apiBase = String(options.apiBase || 'https://api.github.com').replace(/\/$/, '');
+  const token = options.token ?? process.env.GITHUB_TOKEN ?? '';
+  const outputPath = options.outputPath || path.join(root, 'published-release-verification.json');
+
+  assert(/^v\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)?$/.test(tag), `Invalid release tag: ${tag}`);
+  assert(tag === `v${version}`, `Release tag ${tag} does not match manifest version ${version}`);
+
+  const release = await fetchJson(
+    `${apiBase}/repos/${repository}/releases/tags/${encodeURIComponent(tag)}`,
+    token
+  );
+  assert(release.tag_name === tag, `Release API returned tag ${release.tag_name || '<missing>'}`);
+  assert(release.draft === false, 'Published release must not be a draft');
+  assert(release.prerelease === false, 'Published release must not be a prerelease');
+
+  const zipAsset = findUploadedAsset(release, 'page-to-md-pro.zip');
+  const evidenceAsset = findUploadedAsset(release, 'release-evidence.json');
+  const tagCommit = await resolveTagCommit(apiBase, repository, tag, token);
+
+  const evidenceBytes = await downloadBytes(evidenceAsset.browser_download_url, token);
+  assertSize(evidenceAsset, evidenceBytes, 'release-evidence.json');
+
+  let evidence;
+  try {
+    evidence = JSON.parse(evidenceBytes.toString('utf8'));
+  } catch (error) {
+    throw new Error(`release-evidence.json is not valid JSON: ${error.message}`);
+  }
+
+  validateDeliveryEvidence(evidence, { repository, version, tag, tagCommit });
+  assert(
+    release.target_commitish === evidence.commit,
+    `Release target ${release.target_commitish || '<missing>'} does not match evidence commit ${evidence.commit}`
+  );
+
+  const zipBytes = await downloadBytes(zipAsset.browser_download_url, token);
+  assertSize(zipAsset, zipBytes, 'page-to-md-pro.zip');
+  const zip = await inspectReleaseZip(zipBytes, version);
+
+  const report = {
+    schemaVersion: 1,
+    verifiedAt: new Date().toISOString(),
+    repository,
+    tag,
+    version,
+    commit: evidence.commit,
+    release: {
+      name: release.name || '',
+      url: release.html_url || '',
+      publishedAt: release.published_at || '',
+      draft: release.draft,
+      prerelease: release.prerelease,
+      targetCommitish: release.target_commitish,
+      assets: [zipAsset.name, evidenceAsset.name].sort()
+    },
+    chromeWebStoreUpload: evidence.chromeWebStoreUpload,
+    publishSubmission: evidence.publishSubmission,
+    publishType: evidence.publishType,
+    skipReview: evidence.skipReview,
+    evidenceVerifiedAt: evidence.verifiedAt,
+    verifiedLogMarkers: [...evidence.verifiedLogMarkers],
+    zip
+  };
+
+  await writeFile(outputPath, `${JSON.stringify(report, null, 2)}\n`);
+  return report;
+}
+
+function findUploadedAsset(release, name) {
+  const asset = Array.isArray(release.assets)
+    ? release.assets.find((candidate) => candidate?.name === name)
+    : null;
+  assert(asset, `GitHub Release is missing ${name}`);
+  assert(asset.state === 'uploaded', `${name} is not in uploaded state`);
+  assert(typeof asset.browser_download_url === 'string' && asset.browser_download_url, `${name} has no download URL`);
+  return asset;
+}
+
+async function resolveTagCommit(apiBase, repository, tag, token) {
+  const reference = await fetchJson(
+    `${apiBase}/repos/${repository}/git/ref/tags/${encodeURIComponent(tag)}`,
+    token
+  );
+  const object = reference.object;
+  assert(object && typeof object.sha === 'string', `Tag ${tag} has no Git object`);
+  if (object.type === 'commit') return object.sha;
+  assert(object.type === 'tag', `Tag ${tag} points to unsupported object type ${object.type || '<missing>'}`);
+
+  const annotated = await fetchJson(`${apiBase}/repos/${repository}/git/tags/${object.sha}`, token);
+  assert(annotated.object?.type === 'commit', `Annotated tag ${tag} does not point to a commit`);
+  assert(typeof annotated.object.sha === 'string', `Annotated tag ${tag} has no commit SHA`);
+  return annotated.object.sha;
+}
+
+function validateDeliveryEvidence(evidence, expected) {
+  assert(evidence && typeof evidence === 'object', 'Release evidence must be an object');
+  assert(evidence.schemaVersion === 1, 'Release evidence schemaVersion must be 1');
+  assert(evidence.repository === expected.repository, `Evidence repository must be ${expected.repository}`);
+  assert(evidence.version === expected.version, `Evidence version must be ${expected.version}`);
+  assert(evidence.tag === expected.tag, `Evidence tag must be ${expected.tag}`);
+  assert(evidence.commit === expected.tagCommit, `Evidence commit must match tag target ${expected.tagCommit}`);
+  assert(evidence.eventName === 'push', 'Release delivery must originate from a main-branch push');
+  assert(evidence.publishType === 'UPLOAD_ONLY', 'Evidence publishType must be UPLOAD_ONLY');
+  assert(evidence.skipReview === false, 'Evidence skipReview must be false');
+  assert(evidence.chromeWebStoreUpload === 'SUCCEEDED', 'Chrome Web Store upload must be SUCCEEDED');
+  assert(evidence.publishSubmission === 'SKIPPED', 'Chrome Web Store publish submission must be SKIPPED');
+  assert(Array.isArray(evidence.verifiedLogMarkers), 'Evidence verifiedLogMarkers must be an array');
+  for (const marker of ['Upload finished successfully.', 'Skipping publish step.']) {
+    assert(evidence.verifiedLogMarkers.includes(marker), `Evidence is missing log marker: ${marker}`);
+  }
+  assert(typeof evidence.verifiedAt === 'string' && !Number.isNaN(Date.parse(evidence.verifiedAt)), 'Evidence verifiedAt must be an ISO timestamp');
+}
+
+async function inspectReleaseZip(zipBytes, expectedVersion) {
+  const temp = await mkdtemp(path.join(os.tmpdir(), 'p2m-release-verify-'));
+  const zipPath = path.join(temp, 'page-to-md-pro.zip');
+  try {
+    await writeFile(zipPath, zipBytes);
+    const listing = run('unzip', ['-Z1', zipPath]);
+    const entries = listing.split(/\r?\n/).filter(Boolean).sort();
+    assert(
+      JSON.stringify(entries) === JSON.stringify(RELEASE_RUNTIME_FILES),
+      `Release ZIP entries differ from the exact allowlist:\n${entries.join('\n')}`
+    );
+
+    const manifestText = run('unzip', ['-p', zipPath, 'manifest.json']);
+    let embeddedManifest;
+    try {
+      embeddedManifest = JSON.parse(manifestText);
+    } catch (error) {
+      throw new Error(`Release ZIP manifest.json is invalid: ${error.message}`);
+    }
+    assert(embeddedManifest.manifest_version === 3, 'Release ZIP manifest_version must be 3');
+    assert(embeddedManifest.version === expectedVersion, `Release ZIP manifest version must be ${expectedVersion}`);
+
+    return {
+      sha256: createHash('sha256').update(zipBytes).digest('hex'),
+      bytes: zipBytes.length,
+      entryCount: entries.length,
+      entries,
+      manifestVersion: embeddedManifest.version
+    };
+  } finally {
+    await rm(temp, { recursive: true, force: true });
+  }
+}
+
+function run(command, args) {
+  const result = spawnSync(command, args, { encoding: 'utf8' });
+  if (result.status !== 0) {
+    throw new Error(result.stderr || result.stdout || `${command} exited with status ${result.status}`);
+  }
+  return result.stdout;
+}
+
+async function fetchJson(url, token) {
+  const response = await request(url, token, 'application/vnd.github+json');
+  try {
+    return await response.json();
+  } catch (error) {
+    throw new Error(`Could not parse JSON from ${url}: ${error.message}`);
+  }
+}
+
+async function downloadBytes(url, token) {
+  const response = await request(url, token, 'application/octet-stream');
+  return Buffer.from(await response.arrayBuffer());
+}
+
+async function request(url, token, accept) {
+  const headers = {
+    Accept: accept,
+    'User-Agent': 'page-to-md-pro-published-release-verifier',
+    'X-GitHub-Api-Version': '2022-11-28'
+  };
+  if (token) headers.Authorization = `Bearer ${token}`;
+
+  const response = await fetch(url, { headers, redirect: 'follow' });
+  if (!response.ok) {
+    const body = (await response.text()).slice(0, 1_000);
+    throw new Error(`Request failed (${response.status} ${response.statusText}) for ${url}: ${body}`);
+  }
+  return response;
+}
+
+function assertSize(asset, bytes, name) {
+  if (Number.isInteger(asset.size)) {
+    assert(bytes.length === asset.size, `${name} downloaded ${bytes.length} bytes but GitHub reports ${asset.size}`);
+  }
+}
+
+function assert(condition, message) {
+  if (!condition) throw new Error(message);
+}
+
+const entry = process.argv[1] ? pathToFileURL(path.resolve(process.argv[1])).href : '';
+if (entry === import.meta.url) {
+  verifyPublishedRelease()
+    .then((report) => {
+      console.log(JSON.stringify(report, null, 2));
+    })
+    .catch((error) => {
+      console.error(error.message || error);
+      process.exitCode = 1;
+    });
+}

--- a/tests/published-release.test.mjs
+++ b/tests/published-release.test.mjs
@@ -1,0 +1,171 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { once } from 'node:events';
+import { createServer } from 'node:http';
+import { createHash } from 'node:crypto';
+import { spawnSync } from 'node:child_process';
+import { mkdtemp, mkdir, readFile, rm, writeFile } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import {
+  RELEASE_RUNTIME_FILES,
+  verifyPublishedRelease
+} from '../scripts/verify-published-release.mjs';
+
+const REPOSITORY = 'test-owner/test-repo';
+const TAG = 'v0.2.0';
+const VERSION = '0.2.0';
+const COMMIT = '0123456789abcdef0123456789abcdef01234567';
+
+async function createReleaseFixture(t, evidenceOverrides = {}) {
+  const temp = await mkdtemp(path.join(os.tmpdir(), 'p2m-published-release-'));
+  t.after(async () => rm(temp, { recursive: true, force: true }));
+
+  const stage = path.join(temp, 'stage');
+  await mkdir(stage, { recursive: true });
+  for (const relativePath of RELEASE_RUNTIME_FILES) {
+    const absolutePath = path.join(stage, relativePath);
+    await mkdir(path.dirname(absolutePath), { recursive: true });
+    const body = relativePath === 'manifest.json'
+      ? `${JSON.stringify({ manifest_version: 3, name: 'Page to Markdown Pro', version: VERSION }, null, 2)}\n`
+      : `${relativePath}\n`;
+    await writeFile(absolutePath, body);
+  }
+
+  const zipPath = path.join(temp, 'page-to-md-pro.zip');
+  const zip = spawnSync('zip', ['-X', '-q', zipPath, ...RELEASE_RUNTIME_FILES], {
+    cwd: stage,
+    encoding: 'utf8'
+  });
+  assert.equal(zip.status, 0, zip.stderr || zip.stdout);
+  const zipBytes = await readFile(zipPath);
+
+  const evidence = {
+    schemaVersion: 1,
+    repository: REPOSITORY,
+    version: VERSION,
+    tag: TAG,
+    commit: COMMIT,
+    eventName: 'push',
+    publishType: 'UPLOAD_ONLY',
+    skipReview: false,
+    chromeWebStoreUpload: 'SUCCEEDED',
+    publishSubmission: 'SKIPPED',
+    verifiedLogMarkers: [
+      'Upload finished successfully.',
+      'Skipping publish step.'
+    ],
+    verifiedAt: '2026-07-19T23:30:00.000Z',
+    ...evidenceOverrides
+  };
+  const evidenceBytes = Buffer.from(`${JSON.stringify(evidence, null, 2)}\n`);
+
+  const server = createServer((request, response) => {
+    const origin = `http://${request.headers.host}`;
+    const releasePath = `/repos/${REPOSITORY}/releases/tags/${TAG}`;
+    const tagPath = `/repos/${REPOSITORY}/git/ref/tags/${TAG}`;
+
+    if (request.url === releasePath) {
+      response.setHeader('content-type', 'application/json');
+      response.end(JSON.stringify({
+        tag_name: TAG,
+        name: 'Page to Markdown Pro 0.2.0',
+        draft: false,
+        prerelease: false,
+        target_commitish: COMMIT,
+        html_url: `${origin}/release-page`,
+        published_at: '2026-07-19T23:30:01.000Z',
+        assets: [
+          {
+            name: 'page-to-md-pro.zip',
+            state: 'uploaded',
+            size: zipBytes.length,
+            browser_download_url: `${origin}/assets/page-to-md-pro.zip`
+          },
+          {
+            name: 'release-evidence.json',
+            state: 'uploaded',
+            size: evidenceBytes.length,
+            browser_download_url: `${origin}/assets/release-evidence.json`
+          }
+        ]
+      }));
+      return;
+    }
+
+    if (request.url === tagPath) {
+      response.setHeader('content-type', 'application/json');
+      response.end(JSON.stringify({ object: { type: 'commit', sha: COMMIT } }));
+      return;
+    }
+
+    if (request.url === '/assets/page-to-md-pro.zip') {
+      response.setHeader('content-type', 'application/zip');
+      response.end(zipBytes);
+      return;
+    }
+
+    if (request.url === '/assets/release-evidence.json') {
+      response.setHeader('content-type', 'application/json');
+      response.end(evidenceBytes);
+      return;
+    }
+
+    response.statusCode = 404;
+    response.end('not found');
+  });
+
+  server.listen(0, '127.0.0.1');
+  await once(server, 'listening');
+  t.after(() => server.close());
+  const address = server.address();
+  assert.ok(address && typeof address === 'object');
+
+  return {
+    apiBase: `http://127.0.0.1:${address.port}`,
+    outputPath: path.join(temp, 'published-release-verification.json'),
+    zipSha256: createHash('sha256').update(zipBytes).digest('hex')
+  };
+}
+
+test('verifies upload-only evidence, release assets, tag target, and ZIP contents', async (t) => {
+  const fixture = await createReleaseFixture(t);
+  const report = await verifyPublishedRelease({
+    repository: REPOSITORY,
+    tag: TAG,
+    apiBase: fixture.apiBase,
+    outputPath: fixture.outputPath
+  });
+
+  assert.equal(report.repository, REPOSITORY);
+  assert.equal(report.tag, TAG);
+  assert.equal(report.version, VERSION);
+  assert.equal(report.commit, COMMIT);
+  assert.equal(report.chromeWebStoreUpload, 'SUCCEEDED');
+  assert.equal(report.publishSubmission, 'SKIPPED');
+  assert.equal(report.publishType, 'UPLOAD_ONLY');
+  assert.equal(report.zip.sha256, fixture.zipSha256);
+  assert.equal(report.zip.entryCount, RELEASE_RUNTIME_FILES.length);
+  assert.deepEqual(report.zip.entries, [...RELEASE_RUNTIME_FILES].sort());
+
+  const persisted = JSON.parse(await readFile(fixture.outputPath, 'utf8'));
+  assert.deepEqual(persisted, report);
+});
+
+test('rejects evidence that requested a publication submission', async (t) => {
+  const fixture = await createReleaseFixture(t, {
+    publishType: 'DEFAULT_PUBLISH',
+    publishSubmission: 'REQUESTED',
+    verifiedLogMarkers: ['Upload finished successfully.']
+  });
+
+  await assert.rejects(
+    verifyPublishedRelease({
+      repository: REPOSITORY,
+      tag: TAG,
+      apiBase: fixture.apiBase,
+      outputPath: fixture.outputPath
+    }),
+    /publishType must be UPLOAD_ONLY/
+  );
+});


### PR DESCRIPTION
## Purpose

Add a permanent independent verifier for published releases.

It fetches the GitHub Release API, resolves the tag target, downloads `release-evidence.json` and `page-to-md-pro.zip`, validates the Chrome Web Store delivery mode, checks the exact ZIP allowlist, and parses the embedded manifest.

## Verified `v0.2.0` result

- release: `Page to Markdown Pro 0.2.0`
- published: `2026-07-19T23:22:47Z`
- tag and release target: `3023d054aac3274fdcacf2fc47998337d127b796`
- Chrome Web Store upload: `SUCCEEDED`
- publish submission: `SKIPPED`
- publish type: `UPLOAD_ONLY`
- skip review: `false`
- release ZIP SHA-256: `42f51f66c06f27e2fca8707d9c1d19a71ddea7e2295000d284b7f185615a53ec`
- release ZIP: 59,553 bytes, exact 18-file allowlist, manifest version `0.2.0`

## Test evidence

The failing-test-first run failed at the aggregate test while the verifier module was absent. After implementation:

- `CI / test`: success
- `Verify Published Release / verify`: success
- verifier contract tests: success
- external GitHub Release and Chrome Web Store evidence verification: success
- verification report uploaded as a GitHub Actions artifact

The workflow runs automatically when its implementation changes, when a release is published, or through manual dispatch. It does not run on ordinary future manifest version bumps before publication.