### PR TITLE
Temporary trigger: apply 0.2.2 renderer patch

### DIFF
--- a/automation-trigger-0.2.2.txt
+++ b/automation-trigger-0.2.2.txt
@@ -1,0 +1,1 @@
+Trigger the temporary same-repository workflow that applies the verified 0.2.2 renderer patch to codex/0.2.2-list-fidelity.


### PR DESCRIPTION
Temporary trigger closed without merge. GitHub only executes pull-request workflows from the default branch in this repository setup, so no production change was applied by this PR.