### PR TITLE
Temporary trigger: patch 0.2.2 feature branch

### DIFF
--- a/automation-trigger-main-0.2.2.txt
+++ b/automation-trigger-main-0.2.2.txt
@@ -1,0 +1,1 @@
+Trigger the temporary default-branch workflow that applies the tested list-renderer patch to codex/0.2.2-list-fidelity and then removes itself.


### PR DESCRIPTION
Closed without merge. Superseded by a fresh trigger branch based on the current `main`, so the merged change matches the active workflow path filter exactly.