### PR TITLE
Temporary merged trigger: apply 0.2.2 list renderer fix

### DIFF
--- a/automation-trigger-main-push-0.2.2.txt
+++ b/automation-trigger-main-push-0.2.2.txt
@@ -1,1 +1,3 @@
 Trigger the existing idempotent workflow that patches codex/0.2.2-list-fidelity and then removes all temporary automation from main.
+
+Merge trigger: 2026-08-02-list-fidelity-green.


### PR DESCRIPTION
This technical PR changes only the existing trigger file. After its verified merge, the already-present self-cleaning workflow on `main` will:

1. apply the exact red-tested list-renderer correction to `codex/0.2.2-list-fidelity`;
2. remove the obsolete feature-branch patch workflow;
3. remove its own workflow and trigger file from `main`.

No extension runtime file is changed by this PR itself.