### PR TITLE
Temporary trigger: run registered 0.2.2 patch job

### DIFF
--- a/automation-trigger-main-push-0.2.2.txt
+++ b/automation-trigger-main-push-0.2.2.txt
@@ -1,3 +1,3 @@
 Trigger the existing idempotent workflow that patches codex/0.2.2-list-fidelity and then removes all temporary automation from main.
 
-Merge trigger: 2026-08-02-list-fidelity-green.
+Registered CI trigger: 2026-08-02-list-fidelity-green-2.


### PR DESCRIPTION
Closed without merge. The embedded patch block prevented workflow registration. Superseded by a shorter registered-CI job that executes a temporary script from the feature branch.