### PR TITLE
Temporary trigger: run shortened 0.2.2 CI patch job

### DIFF
--- a/automation-trigger-main-push-0.2.2.txt
+++ b/automation-trigger-main-push-0.2.2.txt
@@ -1,3 +1,3 @@
 Trigger the existing idempotent workflow that patches codex/0.2.2-list-fidelity and then removes all temporary automation from main.
 
-Merge trigger: 2026-08-02-list-fidelity-green.
+Short registered CI trigger: 2026-08-02-list-fidelity-green-3.


### PR DESCRIPTION
This one-line technical PR triggers the shortened `patch_0_2_2` job in the registered CI workflow.

The patch implementation lives temporarily in `scripts/temporary-list-fix.py` on the feature branch. On merge, the CI job applies it, commits the renderer correction, removes the temporary feature files, restores the normal CI workflow, and removes all main-branch trigger automation.