### PR TITLE
Temporary trigger: verify published v0.2.2 release

### DIFF
--- a/release-audit-trigger-0.2.2.txt
+++ b/release-audit-trigger-0.2.2.txt
@@ -1,0 +1,1 @@
+Trigger the existing CI audit job to verify the published v0.2.2 GitHub Release assets and Chrome Web Store UPLOAD_ONLY evidence.


### PR DESCRIPTION
This technical PR adds one trigger file only. After its verified merge, the temporary main-push audit job will run the repository's own `verify-published-release.mjs` against `v0.2.2` and post the complete JSON report to merged PR #14.

The verifier independently downloads and checks:

- `page-to-md-pro.zip`
- `release-evidence.json`
- tag and release target commit
- Chrome Web Store `UPLOAD_ONLY` delivery state
- exact 18-file ZIP allowlist
- embedded manifest version
- release ZIP SHA-256

The audit job and trigger file will be removed from `main` after the report is recorded.