### PR TITLE
Release 0.2.3: harden large-download timeouts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to Page to Markdown Pro are documented here.
 
+## [0.2.3] - 2026-08-02
+
+### Added
+
+- Node regression coverage for delayed Chrome download IDs and Blob downloads that never reach a terminal state.
+
+### Fixed
+
+- Started the large-download terminal-state timeout only after Chrome returns a valid download ID, so time spent in the save dialog no longer consumes the transfer timeout.
+- Rejected stalled Blob downloads with stable code `DOWNLOAD_TIMEOUT` instead of reporting unconfirmed completion as success.
+- Preserved deterministic listener and Blob URL cleanup after completion, interruption, start failure, and timeout.
+
 ## [0.2.2] - 2026-08-02
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Page to Markdown Pro is a local-first Chromium extension that exports the active page or highlighted selection as a clean Markdown file.
 
-Version **0.2.2** improves ordered-list fidelity: it preserves zero and negative starts, reversed numbering, item-level counter resets, and marker-aware nested indentation, with browser-level regression coverage and no new host permissions, telemetry, remote code, or runtime dependencies.
+Version **0.2.3** hardens large-download completion tracking: save-dialog time no longer consumes the terminal-state timeout, and stalled Blob downloads fail with a stable error instead of being reported as successful, with no new host permissions, telemetry, remote code, or runtime dependencies.
 
 ## Highlights
 
@@ -15,7 +15,7 @@ Version **0.2.2** improves ordered-list fidelity: it preserves zero and negative
 - Lazy/placeholder-image normalization, image-only selection export, and meaningful video/audio source links.
 - Tracking-parameter removal and active-protocol filtering.
 - Per-tab and per-request capture deduplication, bounded retries, ordered status badges, and timeout errors.
-- Large downloads through an offscreen Blob URL that remains alive until Chrome reports completion or interruption.
+- Large downloads through an offscreen Blob URL that remains alive until Chrome reports completion or interruption, with bounded timeout cleanup for stalled transfers.
 - Local processing only. Page data is not sent to developer-controlled servers.
 
 ## Install locally
@@ -85,7 +85,7 @@ npm run build:zip         # deterministic Chrome Web Store ZIP
 npm run validate:package  # manifest, permissions, files, and ZIP allowlist
 ```
 
-The suite currently includes 36 Node tests and eleven Chromium fixtures covering articles, tables, math, HTML line breaks, ordered-list counters and indentation, nested inline-flow code blocks, Shadow DOM, slots, task lists, JSON-LD, delayed mutations, large DOMs and selections, base-URL resolution, lazy/placeholder images, selection-only media, literal HTML, unsafe protocols, deterministic packaging, and published-release evidence.
+The suite currently includes 38 Node tests and eleven Chromium fixtures covering articles, tables, math, HTML line breaks, ordered-list counters and indentation, nested inline-flow code blocks, Shadow DOM, slots, task lists, JSON-LD, delayed mutations, large DOMs and selections, base-URL resolution, lazy/placeholder images, selection-only media, Blob download completion and timeout boundaries, literal HTML, unsafe protocols, deterministic packaging, and published-release evidence.
 
 ## Release model
 

--- a/docs/releases/0.2.3.md
+++ b/docs/releases/0.2.3.md
@@ -1,0 +1,23 @@
+# Page to Markdown Pro 0.2.3
+
+Released on 2026-08-02.
+
+## What changed
+
+- The terminal-state timeout for large Blob-backed downloads now starts only after Chrome returns a valid download ID.
+- Time spent in Chrome's save dialog no longer consumes the download completion timeout.
+- A large download that never reports `complete` or `interrupted` now rejects with stable error code `DOWNLOAD_TIMEOUT` instead of being reported as successful.
+- Timeout cleanup removes the `chrome.downloads.onChanged` listener and revokes the offscreen Blob URL exactly once.
+- Existing completion and interruption behavior remains unchanged.
+- Two controller-level regression tests cover both timing boundaries through the real background implementation.
+
+## Compatibility and security
+
+- No extension permissions, host permissions, content scripts, runtime dependencies, telemetry, or remote executable code were added.
+- The minimum supported Chrome version remains 109.
+- Small downloads continue to use the data-URL transport; only large Blob-backed download lifecycle handling changed.
+- Automated delivery remains `UPLOAD_ONLY`: the package is uploaded to Chrome Web Store but is not submitted for publication automatically.
+
+## Verification gates
+
+The release candidate must pass all 38 Node tests, all eleven Chromium fixtures, the aggregate `npm test` command, deterministic ZIP construction, and exact 18-file package allowlist validation before merge. The main-branch release workflow repeats the complete verification before Chrome Web Store upload and GitHub Release creation.

--- a/docs/superpowers/plans/2026-08-02-page-to-md-pro-0.2.3-blob-download-timeout.md
+++ b/docs/superpowers/plans/2026-08-02-page-to-md-pro-0.2.3-blob-download-timeout.md
@@ -1,0 +1,157 @@
+# Page to Markdown Pro 0.2.3 Blob Download Timeout Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Prevent slow or stalled Blob downloads from being reported as successful, without charging save-dialog time against the transfer timeout.
+
+**Architecture:** Keep the existing background-controller API and offscreen Blob transport. Move timeout creation from observer construction into `waitFor(downloadId)`, reject on expiry, and prove both timing boundaries with real controller tests.
+
+**Tech Stack:** Manifest V3 JavaScript, Node.js 24, `node:test`, Chrome downloads/offscreen APIs, GitHub Actions.
+
+## Global Constraints
+
+- Release version: `0.2.3` / tag `v0.2.3`.
+- Keep `manifest_version` 3 and minimum Chrome version 109.
+- Add no permissions, host permissions, content scripts, telemetry, remote code, or runtime dependencies.
+- Keep automated Chrome Web Store delivery in `UPLOAD_ONLY` mode.
+
+---
+
+### Task 1: Add failing timeout regression tests
+
+**Files:**
+- Modify: `tests/background.test.mjs`
+
+**Interfaces:**
+- Consumes: `createBackgroundController()` and the existing Chrome test harness.
+- Produces: two tests proving timeout start and timeout rejection behavior.
+
+- [ ] **Step 1: Add the delayed-download-ID test**
+
+Add a test that replaces `chrome.downloads.download()` with a deferred promise, waits longer than `downloadTimeoutMs`, then resolves download ID `7`. Assert the export is still pending until an explicit `complete` event is emitted.
+
+- [ ] **Step 2: Add the terminal-state timeout test**
+
+Start a Blob download with a short timeout and emit no terminal event. Assert rejection with `error.code === 'DOWNLOAD_TIMEOUT'`, one Blob revoke message, and zero remaining download listeners.
+
+- [ ] **Step 3: Verify RED**
+
+Run:
+
+```bash
+node --test tests/background.test.mjs
+```
+
+Expected: both new tests fail against 0.2.2 because the timer starts too early and resolves as success on expiry.
+
+- [ ] **Step 4: Commit tests before production code**
+
+```bash
+git add tests/background.test.mjs
+git commit -m "test: reproduce Blob download timeout bugs"
+```
+
+---
+
+### Task 2: Correct observer timeout semantics
+
+**Files:**
+- Modify: `src/background.js`
+
+**Interfaces:**
+- Consumes: the existing private `createDownloadObserver(timeoutMs)` helper.
+- Produces: unchanged public controller API with stable `DOWNLOAD_TIMEOUT` rejection.
+
+- [ ] **Step 1: Defer timer creation**
+
+Replace the construction-time timer with `let timer = null` and start it inside `waitFor(downloadId)` after assigning `targetId`.
+
+- [ ] **Step 2: Reject on timeout**
+
+Use:
+
+```js
+settle.reject(codedError(
+  'DOWNLOAD_TIMEOUT',
+  'The Markdown download did not complete before the timeout.'
+));
+```
+
+- [ ] **Step 3: Preserve cleanup**
+
+Keep `close()` idempotent, clear the timer only when present, and retain listener removal. Do not change completion, interruption, or Blob revocation behavior.
+
+- [ ] **Step 4: Verify GREEN**
+
+Run:
+
+```bash
+node --test tests/background.test.mjs
+npm test
+npm run build:zip
+npm run validate:package
+```
+
+Expected: all commands exit 0.
+
+- [ ] **Step 5: Commit implementation**
+
+```bash
+git add src/background.js
+git commit -m "fix: reject timed-out Blob downloads"
+```
+
+---
+
+### Task 3: Prepare release 0.2.3
+
+**Files:**
+- Modify: `manifest.json`
+- Modify: `package.json`
+- Modify: `package-lock.json`
+- Modify: `tests/package.test.mjs`
+- Modify: `README.md`
+- Modify: `CHANGELOG.md`
+- Create: `docs/releases/0.2.3.md`
+
+**Interfaces:**
+- Produces: synchronized version metadata and release documentation for `v0.2.3`.
+
+- [ ] **Step 1: Synchronize version metadata**
+
+Set all enforced version fields and package-test assertions to `0.2.3`.
+
+- [ ] **Step 2: Update test counts**
+
+Update README from 36 to 38 Node tests while keeping 11 Chromium fixtures.
+
+- [ ] **Step 3: Document the patch**
+
+Add changelog and release notes describing delayed timer start, truthful timeout failure, stable error code, cleanup behavior, and unchanged security/permission model.
+
+- [ ] **Step 4: Commit release preparation**
+
+```bash
+git add manifest.json package.json package-lock.json tests/package.test.mjs README.md CHANGELOG.md docs/releases/0.2.3.md
+git commit -m "chore: prepare release 0.2.3"
+```
+
+---
+
+### Task 4: Verify, merge, release, and audit
+
+- [ ] **Step 1: Require green pull-request CI**
+
+Confirm focused tests, all 38 Node tests, all 11 Chromium fixtures, aggregate `npm test`, deterministic ZIP build, source validation, ZIP allowlist validation, and artifact upload succeed.
+
+- [ ] **Step 2: Review diff**
+
+Confirm production scope is limited to observer timer semantics and that no permission or dependency changed.
+
+- [ ] **Step 3: Merge to `main`**
+
+Merge only after green CI using the repository's normal squash workflow.
+
+- [ ] **Step 4: Verify release delivery**
+
+Confirm tag `v0.2.3`, GitHub Release assets `page-to-md-pro.zip` and `release-evidence.json`, Chrome Web Store upload state `SUCCEEDED`, publish submission `SKIPPED`, and publish type `UPLOAD_ONLY`.

--- a/docs/superpowers/specs/2026-08-02-page-to-md-pro-0.2.3-blob-download-timeout-design.md
+++ b/docs/superpowers/specs/2026-08-02-page-to-md-pro-0.2.3-blob-download-timeout-design.md
@@ -1,0 +1,56 @@
+# Page to Markdown Pro 0.2.3 Blob Download Timeout Design
+
+## Context
+
+Large Markdown exports use an offscreen Blob URL and wait for `chrome.downloads.onChanged` to report a terminal state. The current observer starts its timer before `chrome.downloads.download()` returns and resolves successfully when the timer expires.
+
+This creates two incorrect behaviors:
+
+1. Time spent in Chrome's `saveAs` dialog consumes the transfer timeout even though no download ID exists yet.
+2. If no terminal event arrives before the timeout, the operation is reported as successful and the Blob URL is revoked.
+
+The second behavior is especially dangerous because callers receive a success result even though completion was never confirmed.
+
+## Goal
+
+Make large-download completion reporting truthful and deterministic:
+
+- start the terminal-state timeout only after Chrome returns a download ID;
+- reject timed-out downloads with stable code `DOWNLOAD_TIMEOUT`;
+- preserve the existing cleanup guarantee for listeners and Blob URLs;
+- retain completion and interruption behavior unchanged.
+
+## Design
+
+`createDownloadObserver()` will continue registering its event listener before `chrome.downloads.download()` starts so very fast terminal events can be buffered. It will no longer start a timer during construction.
+
+`waitFor(downloadId)` will:
+
+1. set the target download ID;
+2. start the timeout exactly once;
+3. process any buffered terminal event for that ID;
+4. return the shared terminal-state promise.
+
+The timeout will reject with:
+
+```js
+codedError(
+  'DOWNLOAD_TIMEOUT',
+  'The Markdown download did not complete before the timeout.'
+)
+```
+
+The existing `finally` block in `downloadMarkdown()` will still close the observer and revoke the Blob URL for success, interruption, start failure, and timeout.
+
+## Regression Coverage
+
+Two Node tests will exercise observable behavior through the real background controller:
+
+1. A delayed `downloads.download()` result must not consume the terminal-state timeout. After the ID is returned, the operation must remain pending until a completion event arrives.
+2. A started Blob download with no terminal event must reject with `DOWNLOAD_TIMEOUT`, revoke the Blob URL once, and remove the `onChanged` listener.
+
+## Compatibility and Security
+
+- No permissions, host permissions, content scripts, runtime dependencies, telemetry, or remote code are added.
+- Minimum Chrome version remains 109.
+- The release flow remains Chrome Web Store `UPLOAD_ONLY`.

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Page to Markdown Pro",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "minimum_chrome_version": "109",
   "description": "Export pages and selections to clean Markdown, with reliable support for docs, code, tables, math, task lists, and web components.",
   "permissions": [

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "page-to-md-pro",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "page-to-md-pro",
-      "version": "0.2.2",
+      "version": "0.2.3",
       "license": "MIT",
       "devDependencies": { "playwright": "1.61.1" },
       "engines": { "node": ">=24.0.0" }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "page-to-md-pro",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "private": true,
   "description": "Local-first Chromium extension that exports pages and selections as high-fidelity Markdown.",
   "type": "module",

--- a/src/background.js
+++ b/src/background.js
@@ -183,8 +183,13 @@ export function createBackgroundController(chromeApi, runtimeOverrides = {}) {
 
   function createDownloadObserver(timeoutMs) {
     const buffered = new Map();
+    const effectiveTimeoutMs = Math.max(
+      1,
+      Number(timeoutMs) || DEFAULT_RUNTIME_OPTIONS.downloadTimeoutMs
+    );
     let targetId = null;
     let settle = null;
+    let timer = null;
     let closed = false;
 
     const promise = new Promise((resolve, reject) => {
@@ -200,10 +205,6 @@ export function createBackgroundController(chromeApi, runtimeOverrides = {}) {
       if (delta.id === targetId) processDelta(delta);
     };
 
-    const timer = setTimeout(() => {
-      if (!closed) settle.resolve({ state: 'timeout' });
-    }, Math.max(1, Number(timeoutMs) || DEFAULT_RUNTIME_OPTIONS.downloadTimeoutMs));
-
     chromeApi.downloads.onChanged.addListener(listener);
 
     function processDelta(delta) {
@@ -218,14 +219,27 @@ export function createBackgroundController(chromeApi, runtimeOverrides = {}) {
     return {
       async waitFor(downloadId) {
         targetId = downloadId;
+        if (timer === null) {
+          timer = setTimeout(() => {
+            if (!closed) {
+              settle.reject(codedError(
+                'DOWNLOAD_TIMEOUT',
+                'The Markdown download did not complete before the timeout.'
+              ));
+            }
+          }, effectiveTimeoutMs);
+        }
         const earlier = buffered.get(downloadId);
-        if (earlier) processDelta(earlier);
+        if (earlier) {
+          buffered.delete(downloadId);
+          processDelta(earlier);
+        }
         return promise;
       },
       close() {
         if (closed) return;
         closed = true;
-        clearTimeout(timer);
+        if (timer !== null) clearTimeout(timer);
         chromeApi.downloads.onChanged.removeListener(listener);
       }
     };

--- a/tests/background.test.mjs
+++ b/tests/background.test.mjs
@@ -184,7 +184,7 @@ test('starts the Blob download timeout only after Chrome returns a download ID',
   };
   const controller = createBackgroundController(harness.chrome, {
     dataUrlThreshold: 10,
-    downloadTimeoutMs: 15
+    downloadTimeoutMs: 100
   });
 
   let settled = false;
@@ -194,7 +194,7 @@ test('starts the Blob download timeout only after Chrome returns a download ID',
     () => { settled = true; }
   );
 
-  await new Promise((resolve) => setTimeout(resolve, 40));
+  await new Promise((resolve) => setTimeout(resolve, 150));
   assert.equal(settled, false, 'waiting for Chrome to return a download ID must not consume the terminal-state timeout');
 
   downloadStart.resolve(7);
@@ -210,7 +210,7 @@ test('rejects and cleans up when a Blob download never reaches a terminal state'
   const harness = createChromeHarness();
   const controller = createBackgroundController(harness.chrome, {
     dataUrlThreshold: 10,
-    downloadTimeoutMs: 20
+    downloadTimeoutMs: 30
   });
 
   const pending = controller.downloadMarkdown('x'.repeat(100), 'stalled.md', false);

--- a/tests/background.test.mjs
+++ b/tests/background.test.mjs
@@ -175,6 +175,55 @@ test('revokes a Blob URL and rejects when the download is interrupted', async ()
   assert.equal(harness.downloadsChanged.size, 0);
 });
 
+test('starts the Blob download timeout only after Chrome returns a download ID', async () => {
+  const harness = createChromeHarness();
+  const downloadStart = deferred();
+  harness.chrome.downloads.download = async () => {
+    harness.calls.downloads += 1;
+    return downloadStart.promise;
+  };
+  const controller = createBackgroundController(harness.chrome, {
+    dataUrlThreshold: 10,
+    downloadTimeoutMs: 15
+  });
+
+  let settled = false;
+  const pending = controller.downloadMarkdown('x'.repeat(100), 'save-dialog.md', true);
+  pending.then(
+    () => { settled = true; },
+    () => { settled = true; }
+  );
+
+  await new Promise((resolve) => setTimeout(resolve, 40));
+  assert.equal(settled, false, 'waiting for Chrome to return a download ID must not consume the terminal-state timeout');
+
+  downloadStart.resolve(7);
+  await new Promise((resolve) => setImmediate(resolve));
+  assert.equal(settled, false, 'a started download must remain pending until a terminal state or post-start timeout');
+
+  harness.downloadsChanged.emit({ id: 7, state: { current: 'complete' } });
+  const result = await pending;
+  assert.equal(result.downloadId, 7);
+});
+
+test('rejects and cleans up when a Blob download never reaches a terminal state', async () => {
+  const harness = createChromeHarness();
+  const controller = createBackgroundController(harness.chrome, {
+    dataUrlThreshold: 10,
+    downloadTimeoutMs: 20
+  });
+
+  const pending = controller.downloadMarkdown('x'.repeat(100), 'stalled.md', false);
+
+  await assert.rejects(
+    pending,
+    (error) => error.code === 'DOWNLOAD_TIMEOUT'
+      && error.message === 'The Markdown download did not complete before the timeout.'
+  );
+  assert.equal(harness.calls.runtimeMessages.filter((message) => message.type === 'page-to-md-revoke-blob').length, 1);
+  assert.equal(harness.downloadsChanged.size, 0);
+});
+
 test('retries one transient extraction messaging failure', async () => {
   const harness = createChromeHarness();
   let attempts = 0;

--- a/tests/package.test.mjs
+++ b/tests/package.test.mjs
@@ -11,12 +11,12 @@ async function assertFile(relativePath) {
   await assert.doesNotReject(access(path.join(root, relativePath)), `Missing ${relativePath}`);
 }
 
-test('manifest and package describe the 0.2.2 module build', async () => {
+test('manifest and package describe the 0.2.3 module build', async () => {
   const [manifest, pkg] = await Promise.all([readJson('manifest.json'), readJson('package.json')]);
   assert.equal(manifest.manifest_version, 3);
   assert.ok(manifest.description.length <= 132, `manifest description is ${manifest.description.length} characters`);
-  assert.equal(manifest.version, '0.2.2');
-  assert.equal(pkg.version, '0.2.2');
+  assert.equal(manifest.version, '0.2.3');
+  assert.equal(pkg.version, '0.2.3');
   assert.equal(pkg.type, 'module');
   assert.equal(manifest.background.service_worker, 'src/background.js');
   assert.equal(manifest.background.type, 'module');


### PR DESCRIPTION
## Summary

- starts the Blob-download terminal-state timeout only after Chrome returns a valid download ID
- prevents time spent in Chrome's `saveAs` dialog from consuming the transfer timeout
- rejects stalled large downloads with stable code `DOWNLOAD_TIMEOUT` instead of returning false success
- preserves completion, interruption, listener cleanup, and one-time Blob URL revocation
- adds two controller-level regression tests
- prepares release `0.2.3` across manifest, package, lockfile, README, changelog, and release notes
- keeps permissions, minimum Chrome version, dependencies, and `UPLOAD_ONLY` release behavior unchanged

## TDD evidence

The tests were committed before the production correction. CI run `30748388089` failed for exactly the two intended behaviors:

1. the operation had already settled after the delayed download ID was returned, proving the timer had started too early;
2. a download with no terminal event resolved instead of rejecting, producing `Missing expected rejection`.

The production diff in `src/background.js` only changes observer timeout semantics: the timer is created in `waitFor(downloadId)`, expiry rejects with `DOWNLOAD_TIMEOUT`, and cleanup remains in the existing `finally` path.

## Final verification

CI run `30748655710` passed completely:

- syntax/control-byte checks: passed for 20 JavaScript files
- focused background suite: **9 passed, 0 failed**
- complete Node suite: **38 passed, 0 failed**
- Chromium fixtures: **11 passed, 0 failed**
- aggregate `npm test`: passed
- source package validation: passed
- deterministic ZIP build: passed
- exact 18-file ZIP allowlist validation: passed
- verified package artifact upload: passed

## Release behavior

After merge to `main`, the existing release workflow repeats the full verification, uploads `page-to-md-pro.zip` to Chrome Web Store in `UPLOAD_ONLY` mode, records delivery evidence, and creates GitHub Release `v0.2.3` only after the upload succeeds. `UPLOAD_ONLY` does not submit the extension for public publication.